### PR TITLE
Updated Method One Downloader for Better Download and Tracking

### DIFF
--- a/downloader_met1.py
+++ b/downloader_met1.py
@@ -20,7 +20,7 @@ import urllib.request
 import json
 
 # Constants
-TARGET_LOC = "D:\\Projects\\VIVY\\Data\\Raw"
+TARGET_LOC = "D:\\Projects\\VIVY\\Data\\Raw\\"
 DATA_HANDLE = DataHandle(TARGET_LOC)
 MONGO_DB = MongoHandle()
 COL = MONGO_DB.get_client()["VIVY"]["cpdlCOL"]
@@ -83,7 +83,7 @@ def process(document: dict) -> None:
                             composer=document["general_information"]["composer"][0],
                             text=text,
                             links=document["download_links"][list(document["download_links"].keys())[0]],
-                            custom_id=f"{document['_id']}_count"
+                            custom_id=f"{document['_id']}_{count}"
                         )
                         print(message["Message"])
                 


### PR DESCRIPTION
## Description

Tracking issues occurred with the previous version of the Method One downloader script. These issues were files not being tracked properly and not being tracked when an error occurred. This means that another MongoDB DB and two other collections within this DB will be made when this script runs.

## Changelog

- Fixed index overwrite issues that caused missing index tracking
- Added an error handler class to note documents/data that faced errors during insertion
- Changed the ways documents are ID'd; they are now ID'd based off the document they were originating from.

## Direction

`method_one` ---> `Development`

## Other Information

N/A

## Checks and Questions

[❌] Does this break previous versions?

[✔️] Did you test this branch and does functionality works?

[✔️] Did you add documentation to the changes you made?

[✔️] Are you sure? Just making sure.
